### PR TITLE
Fixed proper url for annotations trainval 2017

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -271,7 +271,7 @@ if test_run:
   ]
 else:
   download_requests = [
-    DownloadRequest("annotations_trainval2017", "http://images.cocodataset.org/annotations/stuff_annotations_trainval2017.zip", download_path),
+    DownloadRequest("annotations_trainval2017", "http://images.cocodataset.org/annotations/annotations_trainval2017.zip", download_path),
     DownloadRequest("val2017", "http://images.cocodataset.org/zips/val2017.zip", download_path),
     DownloadRequest("train2017", "http://images.cocodataset.org/zips/train2017.zip", download_path),
   ]


### PR DESCRIPTION
Unfortunately, old url was for "stuff_annotations", which would not suffice